### PR TITLE
Fix empty PATH for subprocess calls

### DIFF
--- a/updown.py
+++ b/updown.py
@@ -41,7 +41,7 @@ def call(cmd, args):
     # run command
     if DEBUG_CALLS:
         sys.stderr.write("executing: " + " ".join(cmd) + "\n")
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, env={"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"})
 
 
 def nsexec(cmd, args=()):


### PR DESCRIPTION
Fixes #2 

It seems like OpenVPN fills the environment for the updown script only with specific variables, but leaves the `PATH` empty.
Maybe this is dependent on OpenVPN version or system configuration, but for me the `ip` and `iptables` executables were not found by the subprocess.

This fix justs sets the `PATH` manually for the subprocess calls.